### PR TITLE
Fix typo in BlGridLayoutExample

### DIFF
--- a/src/Bloc-Examples/BlGridLayoutExamples.class.st
+++ b/src/Bloc-Examples/BlGridLayoutExamples.class.st
@@ -70,7 +70,7 @@ BlGridLayoutExamples >> exampleCellSpacingHorizontal1 [
 ]
 
 { #category : #'examples - layout' }
-BlGridLayoutExamples >> exampleCellSpacingVerical1 [
+BlGridLayoutExamples >> exampleCellSpacingVertical1 [
 	<gtExample>
 	| parent childA childB |
 	


### PR DESCRIPTION
This PR fixes a typo in the name of a method in the BlGridLayoutExample, from `verical` to `vertical`.

Cheers