### PR TITLE
Assertion amplification in #testProcessKeyDown

### DIFF
--- a/src/Bloc-Tests/BlKeyboardProcessorTest.class.st
+++ b/src/Bloc-Tests/BlKeyboardProcessorTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'processor',
 		'space'
 	],
-	#category : 'Bloc-Tests-Universe'
+	#category : #'Bloc-Tests-Universe'
 }
 
 { #category : #initialization }
@@ -33,5 +33,6 @@ BlKeyboardProcessorTest >> testProcessKeyDown [
 	eventA key: BlKeyboardKey a.
 
 	processor processKeyDown: eventA.
+	self assert: processor keystrokesAllowed.
 	self assert: (processor buffer hasEvent: BlKeyboardKey a)
 ]


### PR DESCRIPTION
I submit this pull request to suggest a new assertion in `BlKeyboardProcessorTest>>#testProcessKeyDown`.

We noticed that the state revealing method #keystrokesAllowed is never executed by any of the tests in BlKeyboardProcessorTest. Adding an extra assertion in #testProcessKeyDown seems like a good place to increase the code coverage.

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.