### PR TITLE
BlHostEventFetched: Collapse duplicated/similar events to avoid over-processing

### DIFF
--- a/src/Bloc/BlEvent.class.st
+++ b/src/Bloc/BlEvent.class.st
@@ -151,6 +151,13 @@ BlEvent >> bubblingTarget: aTBlEventTarget [
 	currentTarget := aTBlEventTarget
 ]
 
+{ #category : #accessing }
+BlEvent >> canBeCollapsed [
+	"Whether I can be skipped in case there's too many of myself queued."
+
+	^ false
+]
+
 { #category : #testing }
 BlEvent >> canBePropagated [
 	<return: #Boolean>

--- a/src/Bloc/BlHostEventFetcher.class.st
+++ b/src/Bloc/BlHostEventFetcher.class.st
@@ -11,7 +11,7 @@ Class {
 		'eventQueue',
 		'hostSpace'
 	],
-	#category : 'Bloc-Universe - Host'
+	#category : #'Bloc-Universe - Host'
 }
 
 { #category : #accessing }
@@ -35,11 +35,20 @@ BlHostEventFetcher >> enqueueEvent: aBlEvent [
 
 { #category : #'event processing' }
 BlHostEventFetcher >> fetchedEventsDo: aBlock [
-	"Flush event queue and evaluate a given block with every queued event as argument"
-	| theEvents |
+	"I flush the event queue and evaluate a given block with every queued event as an argument.
+	In case there are multiple events of the same kind that can be skipped (such as mouse movements),
+	I will also collapse them into a single event, by only flushing the newest one."
 
+	| theEvents |
 	theEvents := LinkedList new.
-	eventQueue flush: [ :anEvent | theEvents add: anEvent ].
+	eventQueue
+		flush: [ :anEvent | 
+			| theLastEventLink |
+			(anEvent canBeCollapsed
+				and: [ theEvents isNotEmpty
+						and: [ (theLastEventLink := theEvents lastLink) value class = anEvent class ] ])
+				ifTrue: [ theLastEventLink value: anEvent ]
+				ifFalse: [ theEvents add: anEvent ] ].
 	theEvents do: aBlock
 ]
 

--- a/src/Bloc/BlMouseMoveEvent.class.st
+++ b/src/Bloc/BlMouseMoveEvent.class.st
@@ -50,6 +50,11 @@ BlMouseMoveEvent class >> secondary [
 ]
 
 { #category : #accessing }
+BlMouseMoveEvent >> canBeCollapsed [
+	^ true
+]
+
+{ #category : #accessing }
 BlMouseMoveEvent >> delta [
 	^ delta
 ]


### PR DESCRIPTION
BlHostEventFetched can now collapse (i.e. skip) collapse-able events before flushing them. This avoids having to process multiple events that are all essentially identical in a single frame, which can lead to stuttering and, most likely, having the UI feel sluggish when selecting text.