### PR TITLE
Limit window title length on creation in BlRustWindowingHost.class.st

### DIFF
--- a/src/BlocHost-Glutin/BlRustWindowingHost.class.st
+++ b/src/BlocHost-Glutin/BlRustWindowingHost.class.st
@@ -108,7 +108,7 @@ BlRustWindowingHost >> createWindowSpaceFor: aSpace [
 	eventLoop := RustWindowingEventFetcher default eventLoop.
 
 	windowBuilder := eventLoop windowBuilder
-		title: (aSpace title contractTo: 500);
+		title: (aSpace title contractTo: 65535);
 		extent: aSpace extent;
 		withDecorations: aSpace borderless not;
 		withTransparency: aSpace borderless;

--- a/src/BlocHost-Glutin/BlRustWindowingHost.class.st
+++ b/src/BlocHost-Glutin/BlRustWindowingHost.class.st
@@ -108,7 +108,7 @@ BlRustWindowingHost >> createWindowSpaceFor: aSpace [
 	eventLoop := RustWindowingEventFetcher default eventLoop.
 
 	windowBuilder := eventLoop windowBuilder
-		title: aSpace title;
+		title: (aSpace title contractTo: 500);
 		extent: aSpace extent;
 		withDecorations: aSpace borderless not;
 		withTransparency: aSpace borderless;


### PR DESCRIPTION
Fixes [window creation with long title](https://github.com/feenkcom/gtoolkit/issues/3765)

67638 characters of json string was too much :)