### PR TITLE
Add compositor renderer support for `BlBlurBelowEffect`

### DIFF
--- a/src/Bloc-Compositor/BlBlurBelowEffect.extension.st
+++ b/src/Bloc-Compositor/BlBlurBelowEffect.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #BlBlurBelowEffect }
+
+{ #category : #'*Bloc-Compositor' }
+BlBlurBelowEffect >> paintOn: aCompositorPainter offset: anOffset for: anElement thenPaint: aBlock [
+	aCompositorPainter
+		pushFilterBelow: (anElement geometry pathOnSpartaCanvas: aCompositorPainter canvas of: anElement)
+		filter: (BlCompositionBlurFilter radius: self radius)
+		offset: anOffset
+		bounds: anElement invalidationBounds
+		compositing: BlCompositingSeparateLayerMode uniqueInstance
+		thenPaint: aBlock
+]

--- a/src/Bloc-Compositor/BlCompositionBlurFilter.class.st
+++ b/src/Bloc-Compositor/BlCompositionBlurFilter.class.st
@@ -1,0 +1,38 @@
+Class {
+	#name : #BlCompositionBlurFilter,
+	#superclass : #Object,
+	#instVars : [
+		'radius'
+	],
+	#category : #'Bloc-Compositor-Layers'
+}
+
+{ #category : #'instance creation' }
+BlCompositionBlurFilter class >> radius: aNumber [
+	^ self new
+		radius: aNumber;
+		yourself
+]
+
+{ #category : #converting }
+BlCompositionBlurFilter >> asSkiaFilter [
+	^ SkiaCompositorFilter blur: self radius asPoint
+]
+
+{ #category : #converting }
+BlCompositionBlurFilter >> asSymbolTree [
+	^ {
+		#BlurFilter .
+		#radius . self radius
+	}
+]
+
+{ #category : #accessing }
+BlCompositionBlurFilter >> radius [
+	^ radius
+]
+
+{ #category : #accessing }
+BlCompositionBlurFilter >> radius: anObject [
+	radius := anObject
+]

--- a/src/Bloc-Compositor/BlCompositionBufferedPainter.class.st
+++ b/src/Bloc-Compositor/BlCompositionBufferedPainter.class.st
@@ -20,6 +20,11 @@ BlCompositionBufferedPainter >> pushClip: aClipPath offset: anOffset bounds: aRe
 ]
 
 { #category : #'api - layer' }
+BlCompositionBufferedPainter >> pushFilterBelow: aPath filter: aFilter offset: anOffset bounds: aRectangle compositing: aBlCompositingMode thenPaint: aPaintBlock [
+	self error: 'Filter below requires a composition layer in the compositor renderer.'
+]
+
+{ #category : #'api - layer' }
 BlCompositionBufferedPainter >> pushOpacity: anOpacity offset: anOffset bounds: aRectangle compositing: aBlCompositingMode thenPaint: aPaintBlock [
 	self applyOpacity: anOpacity offset: anOffset thenPaint: aPaintBlock
 ]

--- a/src/Bloc-Compositor/BlCompositionFilterBelowLayer.class.st
+++ b/src/Bloc-Compositor/BlCompositionFilterBelowLayer.class.st
@@ -1,0 +1,68 @@
+Class {
+	#name : #BlCompositionFilterBelowLayer,
+	#superclass : #BlCompositionWithOffsetLayer,
+	#instVars : [
+		'filter',
+		'path'
+	],
+	#category : #'Bloc-Compositor-Layers'
+}
+
+{ #category : #converting }
+BlCompositionFilterBelowLayer >> asSkiaLayer [
+	| theChildLayers |
+
+	theChildLayers := self children collect: [ :eachLayer | eachLayer asSkiaLayer ].
+	^ self newSkiaLayer withLayers: theChildLayers
+]
+
+{ #category : #converting }
+BlCompositionFilterBelowLayer >> asSymbolTree [
+	^ {
+		#FilterBelow .
+			#offset . { self offset x . self offset y }.
+			#filter . self filter asSymbolTree.
+			#path . self path class name.
+			self layers collect: [ :eachLayer | eachLayer asSymbolTree ] as: Array
+	}
+]
+
+{ #category : #accessing }
+BlCompositionFilterBelowLayer >> filter [
+	^ filter
+]
+
+{ #category : #accessing }
+BlCompositionFilterBelowLayer >> filter: anObject [
+	filter = anObject
+		ifFalse: [ self markNeedsComposition ].
+	filter := anObject
+]
+
+{ #category : #accessing }
+BlCompositionFilterBelowLayer >> name [
+	^ 'Filter below'
+]
+
+{ #category : #converting }
+BlCompositionFilterBelowLayer >> newSkiaLayer [
+	<return: #SkiaCompositionFilterBelowLayer>
+	| aBuilder |
+
+	aBuilder := SkiaCompositorFilterBelowLayerBuilder new
+		filter: self filter asSkiaFilter;
+		offset: self offset.
+
+	^ self path spartaClipOn: self with: aBuilder
+]
+
+{ #category : #accessing }
+BlCompositionFilterBelowLayer >> path [
+	^ path
+]
+
+{ #category : #accessing }
+BlCompositionFilterBelowLayer >> path: anObject [
+	path := anObject.
+	self markNeedsComposition
+]

--- a/src/Bloc-Compositor/BlCompositionLayeredPainter.class.st
+++ b/src/Bloc-Compositor/BlCompositionLayeredPainter.class.st
@@ -46,6 +46,25 @@ BlCompositionLayeredPainter >> pushClip: aClipPath offset: anOffset bounds: aRec
 		ifFalse: [ self applyClip: aClipPath offset: anOffset thenPaint: aPaintBlock ]
 ]
 
+{ #category : #'api - layer' }
+BlCompositionLayeredPainter >> pushFilterBelow: aPath filter: aFilter offset: anOffset bounds: aRectangle compositing: aBlCompositingMode thenPaint: aPaintBlock [
+	<argument: #anOffset satisfies: #isSpartaScalarPoint>
+
+	aBlCompositingMode wantsCompositionLayer
+		ifTrue: [
+			self
+				pushLayer: (BlCompositionFilterBelowLayer new
+					offset: anOffset;
+					filter: aFilter;
+					path: aPath)
+				offset: 0 @ 0
+				bounds: aRectangle
+				compositing: aBlCompositingMode
+				thenPaint: aPaintBlock ]
+		ifFalse: [
+			self error: 'Filter below requires a composition layer in the compositor renderer.' ]
+]
+
 { #category : #'private - layer' }
 BlCompositionLayeredPainter >> pushLayer: aNewLayer offset: anOffset bounds: aRectangleOrNull compositing: aBlCompositingMode thenPaint: aPaintBlock [
 	<argument: #anOffset satisfies: #isSpartaScalarPoint>
@@ -67,16 +86,30 @@ BlCompositionLayeredPainter >> pushLayer: aNewLayer offset: anOffset bounds: aRe
 { #category : #'api - layer' }
 BlCompositionLayeredPainter >> pushOpacity: anOpacity offset: anOffset bounds: aRectangle compositing: aBlCompositingMode thenPaint: aPaintBlock [
 	<argument: #anOffset satisfies: #isSpartaScalarPoint>
-	
+
 	aBlCompositingMode wantsCompositionLayer
 		ifTrue: [
-			self
-				pushLayer: (BlCompositionOpacityLayer new
-					opacity: anOpacity)
-				offset: anOffset
-				bounds: aRectangle
-				compositing: aBlCompositingMode
-				thenPaint: aPaintBlock ]
+			anOffset isZero
+				ifTrue: [
+					self
+						pushLayer: (BlCompositionOpacityLayer new opacity: anOpacity)
+						offset: 0 @ 0
+						bounds: aRectangle
+						compositing: aBlCompositingMode
+						thenPaint: aPaintBlock ]
+				ifFalse: [
+					self
+						pushLayer: (BlCompositionOffsetLayer new offset: anOffset)
+						offset: 0 @ 0
+						bounds: aRectangle
+						compositing: aBlCompositingMode
+						thenPaint: [ :anOffsetPainter :aLocalOffset |
+							anOffsetPainter
+								pushOpacity: anOpacity
+								offset: aLocalOffset
+								bounds: aRectangle
+								compositing: aBlCompositingMode
+								thenPaint: aPaintBlock ] ] ]
 		ifFalse: [
 			self
 				applyOpacity: anOpacity

--- a/src/Bloc-Compositor/BlCompositionPainter.class.st
+++ b/src/Bloc-Compositor/BlCompositionPainter.class.st
@@ -267,6 +267,11 @@ BlCompositionPainter >> pushClip: aClipPath offset: anOffset bounds: aRectangle 
 ]
 
 { #category : #'api - layer' }
+BlCompositionPainter >> pushFilterBelow: aPath filter: aFilter offset: anOffset bounds: aRectangle compositing: aBlCompositingMode thenPaint: aPaintBlock [
+	self subclassResponsibility
+]
+
+{ #category : #'api - layer' }
 BlCompositionPainter >> pushShadow: aShadowPath shadowOffset: aShadowOffset shadowColor: aShadowColor shadowWidth: aShadowWidth offset: anOffset bounds: aRectangle compositing: aBlCompositingMode thenPaint: aPaintBlock [
 	self subclassResponsibility
 ]

--- a/src/Bloc-Compositor/BlElement.extension.st
+++ b/src/Bloc-Compositor/BlElement.extension.st
@@ -134,16 +134,21 @@ BlElement >> paintMeAndChildrenOn: aCompositorPainter offset: anOffset [
 { #category : #'*Bloc-Compositor' }
 BlElement >> paintMeAndChildrenWithOpacityOn: aCompositorPainter offset: anOffset [
 	<argument: #anOffset satisfies: #isSpartaScalarPoint>
+	| anOpacityCompositingMode |
 
 	(self opacity closeTo: 1.0)
-		ifTrue: [ self paintMeAndChildrenOn: aCompositorPainter offset: anOffset ]
-		ifFalse: [
-			aCompositorPainter
-				pushOpacity: self opacity
-				offset: anOffset
-				bounds: self invalidationBounds
-				compositing: self compositingMode
-				thenPaint: [ :anOpacityPainter :anOpacityOffset | self paintMeAndChildrenOn: anOpacityPainter offset: anOpacityOffset ] ]
+		ifTrue: [ ^ self paintMeAndChildrenOn: aCompositorPainter offset: anOffset ].
+
+	anOpacityCompositingMode := self effect wantsCompositionLayerForOpacity
+		ifTrue: [ BlCompositingSeparateLayerMode uniqueInstance ]
+		ifFalse: [ self compositingMode ].
+	aCompositorPainter
+		pushOpacity: self opacity
+		offset: anOffset
+		bounds: self invalidationBounds
+		compositing: anOpacityCompositingMode
+		thenPaint: [ :anOpacityPainter :anOpacityOffset |
+			self paintMeAndChildrenOn: anOpacityPainter offset: anOpacityOffset ]
 ]
 
 { #category : #'*Bloc-Compositor' }

--- a/src/Bloc-Sparta/BlBlurEffect.extension.st
+++ b/src/Bloc-Sparta/BlBlurEffect.extension.st
@@ -2,22 +2,21 @@ Extension { #name : #BlBlurEffect }
 
 { #category : #'*Bloc-Sparta' }
 BlBlurEffect >> applyOnSpartaCanvas: aSpartaCanvas for: anElement [
-	| anEffectBounds aWindowScale |
+	| anEffectBounds aCanvasTransform aCanvasScale |
 
-	anEffectBounds := anElement localBoundsToWindow: (anElement effectBounds: BlBounds new).
-
-	aWindowScale := anElement isAttachedToSceneGraph
-		ifTrue: [ anElement space windowScale ]
-		ifFalse: [ 1 ].
+	aCanvasTransform := aSpartaCanvas transform current.
+	anEffectBounds := aCanvasTransform
+		transformRectangle: (SpartaRectangle fromRectangle: anElement effectBounds).
+	aCanvasScale := aCanvasTransform scale.
 	
 	aSpartaCanvas clip
 		by: (anElement geometry pathOnSpartaCanvas: aSpartaCanvas of: anElement)
 		during: [
 			aSpartaCanvas transform
-				by: [ :t | t scaleBy: 1.0 / aWindowScale ]
+				by: [ :t | t scaleBy: (1.0 / aCanvasScale x) @ (1.0 / aCanvasScale y) ]
 				during: [
 					aSpartaCanvas filter
-						area: anEffectBounds; "source in device window coordinates"
+						area: anEffectBounds; "source in canvas device coordinates"
 						to: 0@0; "destination in local coordinates of canvas"
 						type: (aSpartaCanvas filters blur
 							stdDeviation: self radius;

--- a/src/Bloc/BlBlurBelowEffect.class.st
+++ b/src/Bloc/BlBlurBelowEffect.class.st
@@ -3,3 +3,15 @@ Class {
 	#superclass : #BlBlurEffect,
 	#category : #'Bloc-Effect'
 }
+
+{ #category : #testing }
+BlBlurBelowEffect >> wantsCompositionLayer [
+	"Blur below must be composed in the parent surface so that it can sample
+	the content behind the element."
+	^ false
+]
+
+{ #category : #testing }
+BlBlurBelowEffect >> wantsCompositionLayerForOpacity [
+	^ true
+]

--- a/src/Bloc/BlElementEffect.class.st
+++ b/src/Bloc/BlElementEffect.class.st
@@ -40,3 +40,8 @@ BlElementEffect >> on: anElement [
 BlElementEffect >> wantsCompositionLayer [
 	^ false
 ]
+
+{ #category : #testing }
+BlElementEffect >> wantsCompositionLayerForOpacity [
+	^ false
+]


### PR DESCRIPTION
`BlBlurBelowEffect` did not have a compositor representation. It could be
applied through the immediate Sparta drawing path, but the compositor renderer
had no way to express "filter the pixels already painted below this element and
then paint the element over the result."

This change maps `BlBlurBelowEffect` onto the generic native filter-below layer
and preserves the correct relationship between:

- the parent surface containing the pixels to filter;
- the element's parent-space position;
- its local foreground drawing;
- transforms and opacity;
- translucent backgrounds, borders, and other foreground content.

This is part of a coordinated group of pull requests across:

- `compositor-rs` (See [https://github.com/feenkcom/compositor-rs/pull/1](https://github.com/feenkcom/compositor-rs/pull/1))
- `libskia`
- `sparta` (See [https://github.com/feenkcom/sparta/pull/13](https://github.com/feenkcom/sparta/pull/13))
- `Bloc`

These changes must be integrated together. This pull request requires a
`libSkia.dylib` built with the coordinated compositor-rs change and the Sparta
bindings that expose the new native filter and composition layer.

## What changed

### Bloc composition model

Added `BlCompositionBlurFilter`, which stores the Bloc blur radius and converts
it to a `SkiaCompositorFilter`.

Added `BlCompositionFilterBelowLayer`, which contains:

- the filter;
- the element geometry path;
- the layer offset;
- foreground child layers.

During native conversion, the layer converts its filter and geometry through
Sparta and attaches its converted child composition layers.

### Blur-below compositor hook

Added a compositor-specific `BlBlurBelowEffect>>paintOn:offset:for:thenPaint:`
implementation. It creates a filter-below layer and records the element's
normal drawing as children of that layer.

This produces the following ordering:

```text
pixels already painted in the parent
    -> filter below
    -> translucent element background
    -> border
    -> foreground/content
```

### Parent-surface ownership

`BlBlurBelowEffect>>wantsCompositionLayer` explicitly answers `false`.

Blur below must remain in the parent surface that owns the pixels behind the
element. Isolating the element into its own surface would cause the filter to
sample an empty or local surface instead of the intended content below it.

### Painter API and local foreground coordinates

Added `pushFilterBelow:filter:offset:bounds:compositing:thenPaint:` to the
composition painter protocol and implemented it in the layered painter.

The filter-below layer stores the element's parent-space offset, while its
foreground children are recorded from local `0@0`. This avoids applying the
element offset twice and keeps backgrounds and borders stable when composition
topology changes during animation.

The buffered painter fails explicitly when asked to apply filter below because
a flattened picture does not own the parent pixels that must be sampled.

### Opacity composition

Added `wantsCompositionLayerForOpacity` to effects. The default is `false`,
while blur below answers `true`.

This distinguishes two requirements:

- blur below itself must not be isolated from the parent surface;
- opacity must group the filtered result and the element foreground together.

## How to test

### Prerequisites

1. Use a `libSkia.dylib` built from the coordinated compositor-rs change.
2. Load the coordinated Sparta branch containing the filter-below FFI wrappers.
3. Load this Bloc branch into the image.

### 1. Static blur-below test

Evaluate:

```smalltalk
| root panel |

root := BlElement new
	geometry: (BlRoundedRectangleGeometry cornerRadius: 18);
	background: Color veryDarkGray;
	layout: BlBasicLayout new;
	clipChildren: true;
	size: 760 @ 300;
	yourself.

root
	addChild: (BlElement new
		background: Color red;
		size: 190 @ 300;
		relocate: 0 @ 0;
		yourself);
	addChild: (BlElement new
		background: Color green;
		size: 190 @ 300;
		relocate: 190 @ 0;
		yourself);
	addChild: (BlElement new
		background: Color blue;
		size: 190 @ 300;
		relocate: 380 @ 0;
		yourself);
	addChild: (BlElement new
		background: Color yellow;
		size: 190 @ 300;
		relocate: 570 @ 0;
		yourself).

panel := BlElement new
	geometry: (BlRoundedRectangleGeometry cornerRadius: 20);
	background: (Color black alpha: 0.2);
	border: (BlBorder paint: Color white width: 4);
	effect: (BlBlurBelowEffect radius: 14);
	layout: BlBasicLayout new;
	size: 300 @ 150;
	relocate: 230 @ 75;
	yourself.

root addChild: panel.
root
```

Expected result:

- colour boundaries remain sharp outside the panel;
- colours are softened inside the panel;
- the translucent black background composites over the filtered result;
- the white border remains visible;
- the panel samples the pixels directly behind its actual position.

### 2. Transform animation

Use the same scene and add the following before returning `root`:

```smalltalk
| animation |

panel transformDo: [ :builder | builder translateBy: -500 @ 0 ].
root forceLayout.

animation := BlTransformAnimation translate: 0 @ 0.
animation
	absolute;
	duration: 3 seconds;
	easing: BlEasing linear.

panel addAnimation: animation.
```

Expected result:

- the filtered source follows the panel throughout the animation;
- the background and border remain aligned with the panel;
- the border remains visible on the final identity-transform frame.

### 3. Opacity animation

Use the same scene and add:

```smalltalk
| animation |

animation := BlOpacityAnimation new
	opacity: 0.25;
	duration: 3 seconds;
	easing: BlEasing linear.

panel addAnimation: animation.
```

Expected result: the filtered result, translucent foreground background, border,
and foreground content fade together as one group.
